### PR TITLE
add allocation base feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.exe
 *.obj
 .DS_Store
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 3.15)
+
+project(blobrunner)
+
+add_executable(${PROJECT_NAME})
+target_sources(${PROJECT_NAME}  PRIVATE blobrunner.c)
+
+


### PR DESCRIPTION
What: Added a feature to force allocation of shell code at certain addresses
why: its nice to keep the analysis and debugger in a single tool,  like IDA, by loading the blobrunner into IDA you can launch the IDA debugger with a process parameter such as `--base 0x50000000` and now navigate to this address and press `alt+s` and change the segment from `debugger` to `loader` now when you stop the IDA debugger you have your shell code in your database and you are free to navigate/analyse it and set breakpoints and launch a debugging session on demand.

what: cmake file
why: if you dev with vscode it makes it very simple(f7 key) to quickly build on demand
